### PR TITLE
Player hurt mechanics and knockback

### DIFF
--- a/UI/UIOverlay.gd
+++ b/UI/UIOverlay.gd
@@ -8,4 +8,4 @@ func _ready():
 	update()
 
 func update():
-	healthBar.value = player.current_Hp * 100 / player.stats.max_Hp
+	healthBar.value = player.currentHealth * 100 / player.stats.max_Hp

--- a/enemies/slime.gd
+++ b/enemies/slime.gd
@@ -56,9 +56,17 @@ func _on_detection_area_body_exited(_body):
 	player = null
 	player_chase = false
 
-func _on_hurt_box_area_entered(_area):
+func _on_hurt_box_area_entered(area):
+	if area.get_parent() == self:
+		return
 	animations.play("deathEffect")
-	$CollisionShape2D.set_deferred("disabled", true)
+	disableCollisions()
 	isDead = true
 	await animations.animation_finished
 	queue_free()
+
+
+func disableCollisions():
+	$CollisionShape2D.set_deferred("disabled", true)
+	$hitBox.set_deferred("monitorable", false)
+	$hitBox.set_deferred("monitoring", false)

--- a/enemies/slime.tscn
+++ b/enemies/slime.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=3 uid="uid://kamkotwvdvp2"]
+[gd_scene load_steps=32 format=3 uid="uid://kamkotwvdvp2"]
 
 [ext_resource type="Script" path="res://enemies/slime.gd" id="1_o864j"]
 [ext_resource type="Texture2D" uid="uid://dgdq28lg5f0ck" path="res://enemies/Slime.png" id="1_qchdh"]
@@ -194,10 +194,16 @@ radius = 37.0135
 size = Vector2(16, 5)
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_i0dwq"]
-radius = 7.0
+radius = 5.0
+height = 18.0
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_d0cc8"]
+radius = 5.0
 height = 18.0
 
 [node name="slime" type="CharacterBody2D"]
+collision_layer = 2
+collision_mask = 3
 motion_mode = 1
 script = ExtResource("1_o864j")
 stats = ExtResource("2_kiprm")
@@ -208,8 +214,8 @@ sprite_frames = SubResource("SpriteFrames_pki3e")
 animation = &"walkDown"
 
 [node name="detection_area" type="Area2D" parent="."]
-collision_layer = 2
-collision_mask = 2
+collision_layer = 0
+collision_mask = 8
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="detection_area"]
 visible = false
@@ -224,9 +230,18 @@ collision_layer = 0
 collision_mask = 4
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="hurtBox"]
-position = Vector2(0, -7)
+position = Vector2(0, -5)
 rotation = 1.5708
 shape = SubResource("CapsuleShape2D_i0dwq")
+
+[node name="hitBox" type="Area2D" parent="."]
+collision_layer = 4
+collision_mask = 8
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="hitBox"]
+position = Vector2(0, -5)
+rotation = 1.5708
+shape = SubResource("CapsuleShape2D_d0cc8")
 
 [connection signal="body_entered" from="detection_area" to="." method="_on_detection_area_body_entered"]
 [connection signal="body_exited" from="detection_area" to="." method="_on_detection_area_body_exited"]

--- a/maps/world.tscn
+++ b/maps/world.tscn
@@ -2791,7 +2791,8 @@ texture = ExtResource("3_hymi6")
 0:0/0/physics_layer_0/angular_velocity = 0.0
 
 [sub_resource type="TileSet" id="TileSet_mf8kr"]
-physics_layer_0/collision_layer = 1
+physics_layer_0/collision_layer = 3
+physics_layer_0/collision_mask = 3
 terrain_set_0/mode = 1
 terrain_set_0/terrain_0/name = "sand"
 terrain_set_0/terrain_0/color = Color(0.477654, 0.260672, 0.658487, 1)
@@ -2827,34 +2828,35 @@ layer_2/y_sort_enabled = true
 layer_2/z_index = 1
 layer_2/tile_data = PackedInt32Array(393219, 1, 0, 524302, 1, 0, 262163, 1, 0, 0, 524289, 12, 65536, 524289, 12, 131072, 524289, 12, 196608, 524289, 12, 262144, 524289, 12, 327680, 524289, 12, 393216, 524289, 12, 458752, 524289, 12, 524288, 524289, 12, 589824, 524289, 12, 655360, 524289, 12, 720896, 524289, 12, 786432, 524289, 12, 851968, 524289, 12, 851969, 524289, 12, 851970, 524289, 12, 851971, 524289, 12, 851972, 524289, 12, 851973, 524289, 12, 851974, 524289, 12, 851975, 524289, 12, 851976, 524289, 12, 851977, 524289, 12, 851978, 524289, 12, 851979, 524289, 12, 851980, 524289, 12, 851981, 524289, 12, 851982, 524289, 12, 851983, 524289, 12, 851984, 524289, 12, 851985, 524289, 12, 851986, 524289, 12, 851987, 524289, 12, 851988, 524289, 12, 851989, 524289, 12, 851990, 524289, 12, 22, 524289, 12, 21, 524289, 12, 20, 524289, 12, 19, 524289, 12, 18, 524289, 12, 17, 524289, 12, 16, 524289, 12, 15, 524289, 12, 14, 524289, 12, 13, 524289, 12, 12, 524289, 12, 11, 524289, 12, 10, 524289, 12, 9, 524289, 12, 8, 524289, 12, 7, 524289, 12, 6, 524289, 12, 5, 524289, 12, 4, 524289, 12, 3, 524289, 12, 2, 524289, 12, 1, 524289, 12, 458753, 524289, 12, 589825, 524289, 12, 786439, 524289, 12, 720903, 524289, 12, 655367, 524289, 12, 655368, 524289, 12, 655371, 524289, 12, 655372, 524289, 12, 720908, 524289, 12, 786444, 524289, 12, 458774, 524289, 12, 524310, 524289, 12, 458773, 524289, 12, 524309, 524289, 12, 524308, 524289, 12, 589845, 524289, 12, 65549, 524289, 12, 65550, 524289, 12, 23, 524289, 12, 24, 524289, 12, 25, 524289, 12, 26, 524289, 12, 27, 524289, 12, 28, 524289, 12, 29, 524289, 12, 30, 524289, 12, 65566, 524289, 12, 131102, 524289, 12, 196638, 524289, 12, 262174, 524289, 12, 524318, 524289, 12, 589854, 524289, 12, 655390, 524289, 12, 720926, 524289, 12, 786462, 524289, 12, 851998, 524289, 12, 851997, 524289, 12, 851996, 524289, 12, 851995, 524289, 12, 851994, 524289, 12, 851993, 524289, 12, 851992, 524289, 12, 851991, 524289, 12, 720921, 1, 0, 720923, 1, 0, 655386, 1, 0, 589849, 1, 0, 589851, 1, 0, 31, 524289, 12, 32, 524289, 12, 33, 524289, 12, 34, 524289, 12, 35, 524289, 12, 36, 524289, 12, 37, 524289, 12, 38, 524289, 12, 39, 524289, 12, 40, 524289, 12, 41, 524289, 12, 42, 524289, 12, 43, 524289, 12, 44, 524289, 12, 45, 524289, 12, 46, 524289, 12, 65582, 524289, 12, 131118, 524289, 12, 196654, 524289, 12, 393262, 524289, 12, 458798, 524289, 12, 524334, 524289, 12, 589870, 524289, 12, 655406, 524289, 12, 720942, 524289, 12, 786478, 524289, 12, 852014, 524289, 12, 262190, 524289, 12, 327726, 524289, 12, 852013, 524289, 12, 852012, 524289, 12, 852011, 524289, 12, 852010, 524289, 12, 852009, 524289, 12, 852008, 524289, 12, 852007, 524289, 12, 852006, 524289, 12, 852005, 524289, 12, 852004, 524289, 12, 852003, 524289, 12, 852002, 524289, 12, 852001, 524289, 12, 852000, 524289, 12, 851999, 524289, 12)
 
-[node name="Player" parent="." instance=ExtResource("1_lvixr")]
+[node name="Player" parent="TileMap" instance=ExtResource("1_lvixr")]
 position = Vector2(171, 86)
 stats = SubResource("Resource_j7dxc")
 
-[node name="FollowCam" type="Camera2D" parent="Player" node_paths=PackedStringArray("tilemap")]
+[node name="FollowCam" type="Camera2D" parent="TileMap/Player" node_paths=PackedStringArray("tilemap")]
 limit_left = 0
 limit_top = 0
 limit_smoothed = true
 position_smoothing_enabled = true
 position_smoothing_speed = 2.0
 script = ExtResource("5_bdext")
-tilemap = NodePath("../../TileMap")
+tilemap = NodePath("../..")
 
-[node name="slime" parent="." node_paths=PackedStringArray("endPoint") instance=ExtResource("6_6gons")]
+[node name="slime2" parent="TileMap" node_paths=PackedStringArray("endPoint") instance=ExtResource("6_6gons")]
+z_index = 1
+position = Vector2(136, 192)
+endPoint = NodePath("Marker2D")
+
+[node name="Marker2D" type="Marker2D" parent="TileMap/slime2"]
+position = Vector2(48, 0)
+
+[node name="slime" parent="TileMap" node_paths=PackedStringArray("endPoint") instance=ExtResource("6_6gons")]
 z_index = 1
 y_sort_enabled = true
 position = Vector2(208, 72)
 endPoint = NodePath("Marker2D")
 
-[node name="Marker2D" type="Marker2D" parent="slime"]
+[node name="Marker2D" type="Marker2D" parent="TileMap/slime"]
 position = Vector2(-16, 72)
 
 [node name="UIOverlay" parent="." node_paths=PackedStringArray("player") instance=ExtResource("8_ia86d")]
-player = NodePath("../Player")
-
-[node name="slime2" parent="." node_paths=PackedStringArray("endPoint") instance=ExtResource("6_6gons")]
-position = Vector2(136, 192)
-endPoint = NodePath("Marker2D")
-
-[node name="Marker2D" type="Marker2D" parent="slime2"]
-position = Vector2(48, 0)
+player = NodePath("../TileMap/Player")

--- a/player/player.gd
+++ b/player/player.gd
@@ -43,14 +43,14 @@ func attack():
 func updateAnimation():
 	if isAttacking: return
 	
-	if velocity.length() == 0:
+	if input_movement.length() == 0:
 		animations["parameters/conditions/isIdle"] = true
 		animations["parameters/conditions/isMoving"] = false
 	else:
 		animations["parameters/conditions/isIdle"] = false
 		animations["parameters/conditions/isMoving"] = true
 		
-		var direction = velocity.normalized()
+		var direction = input_movement.normalized()
 		
 		animations["parameters/Idle/blend_position"] = direction
 		animations["parameters/Move/blend_position"] = direction

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=44 format=3 uid="uid://b8y3gph323o0g"]
+[gd_scene load_steps=45 format=3 uid="uid://b8y3gph323o0g"]
 
 [ext_resource type="Script" path="res://player/player.gd" id="1_8yic0"]
 [ext_resource type="Resource" uid="uid://clj2jfjme6kf2" path="res://player/basePlayer.tres" id="2_ihtot"]
@@ -515,9 +515,13 @@ states/Start/position = Vector2(149, 134)
 transitions = ["Start", "Idle", SubResource("AnimationNodeStateMachineTransition_buln1"), "Idle", "Move", SubResource("AnimationNodeStateMachineTransition_da5gj"), "Move", "Idle", SubResource("AnimationNodeStateMachineTransition_k6svf"), "Attack", "Move", SubResource("AnimationNodeStateMachineTransition_adixg"), "Move", "Attack", SubResource("AnimationNodeStateMachineTransition_7uv3b"), "Attack", "Idle", SubResource("AnimationNodeStateMachineTransition_26nfc"), "Idle", "Attack", SubResource("AnimationNodeStateMachineTransition_0orgj")]
 graph_offset = Vector2(-162, 17)
 
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_1yjqd"]
+radius = 7.0
+height = 14.0
+
 [node name="Player" type="CharacterBody2D"]
 z_index = 1
-collision_layer = 3
+collision_layer = 9
 motion_mode = 1
 script = ExtResource("1_8yic0")
 stats = ExtResource("2_ihtot")
@@ -559,3 +563,13 @@ parameters/conditions/isMoving = false
 parameters/Attack/blend_position = Vector2(0, 0)
 parameters/Idle/blend_position = Vector2(0.00270033, 0.00440526)
 parameters/Move/blend_position = Vector2(0, 0)
+
+[node name="hurtBox" type="Area2D" parent="."]
+collision_layer = 8
+collision_mask = 4
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="hurtBox"]
+position = Vector2(0, -7)
+shape = SubResource("CapsuleShape2D_1yjqd")
+
+[connection signal="area_entered" from="hurtBox" to="." method="_on_hurt_box_area_entered"]

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -403,7 +403,7 @@ _data = {
 }
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_0sqkx"]
-size = Vector2(14, 3)
+size = Vector2(12, 3)
 
 [sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_e2xk3"]
 animation = &"attackDown"
@@ -515,13 +515,13 @@ states/Start/position = Vector2(149, 134)
 transitions = ["Start", "Idle", SubResource("AnimationNodeStateMachineTransition_buln1"), "Idle", "Move", SubResource("AnimationNodeStateMachineTransition_da5gj"), "Move", "Idle", SubResource("AnimationNodeStateMachineTransition_k6svf"), "Attack", "Move", SubResource("AnimationNodeStateMachineTransition_adixg"), "Move", "Attack", SubResource("AnimationNodeStateMachineTransition_7uv3b"), "Attack", "Idle", SubResource("AnimationNodeStateMachineTransition_26nfc"), "Idle", "Attack", SubResource("AnimationNodeStateMachineTransition_0orgj")]
 graph_offset = Vector2(-162, 17)
 
-[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_1yjqd"]
-radius = 7.0
-height = 14.0
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_pnsil"]
+size = Vector2(12, 15)
 
 [node name="Player" type="CharacterBody2D"]
 z_index = 1
 collision_layer = 9
+collision_mask = 3
 motion_mode = 1
 script = ExtResource("1_8yic0")
 stats = ExtResource("2_ihtot")
@@ -569,7 +569,8 @@ collision_layer = 8
 collision_mask = 4
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="hurtBox"]
-position = Vector2(0, -7)
-shape = SubResource("CapsuleShape2D_1yjqd")
+position = Vector2(0, -7.5)
+shape = SubResource("RectangleShape2D_pnsil")
 
 [connection signal="area_entered" from="hurtBox" to="." method="_on_hurt_box_area_entered"]
+[connection signal="area_exited" from="hurtBox" to="." method="_on_hurt_box_area_exited"]

--- a/project.godot
+++ b/project.godot
@@ -33,7 +33,10 @@ attack={
 
 [layer_names]
 
+2d_physics/layer_1="player"
+2d_physics/layer_2="enemy"
 2d_physics/layer_3="hitBoxes"
+2d_physics/layer_4="playerHurtbox"
 
 [rendering]
 

--- a/project.godot
+++ b/project.godot
@@ -25,6 +25,38 @@ window/stretch/mode="canvas_items"
 
 [input]
 
+ui_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+]
+}
+ui_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+]
+}
+ui_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
+]
+}
+ui_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+]
+}
 attack={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)


### PR DESCRIPTION
### Issue

Fixes #24

### Notes

Adds a player hurt mechanic, with hurtboxes and hitboxes on the enemy, as well as a hurtbox for the player

- Player
  - Added hurtBox on its own physics collision layer
  - Signals for area entered and exited
  - hit() method to calculate damage, process knockback, and show hurt animation
  - Invicibility frames after player is hit (Currently set to static 1 second)
- Slime
  - Added hitbox and hurtbox
  - Slime hitbox masked to playerHurtbox layer
  - Slime hurtBox masked to hitBoxes layer
    - This technically allows slimes to kill eachother - this should be fixed in another issue.
- Misc
  - Added collision layers for player, enemy, hitboxes, playerHurtbox
  - Added support for WASD movement input
  - Updated `current_Hp` to `currentHealth`


### Testing

Tested player hurt mechanics with knockback and iframes

https://github.com/KawaProductions/BoyoRPG/assets/3720350/3c89bb71-ae37-4df5-a660-2b7e7d691d18


