### PR TITLE
Player aniplayer to antiree

### DIFF
--- a/player/player.gd
+++ b/player/player.gd
@@ -31,15 +31,14 @@ func handleInput():
 		attack()
 
 func attack():
-	##animations.play("attack" + lastAnimDirection)
-	isAttacking = true
+	animations["parameters/conditions/isAttacking"] = true
 	weapon.enable()
-	##await animations.animation_finished
+	await animations.animation_finished
 	weapon.disable()
-	isAttacking = false
+	animations["parameters/conditions/isAttacking"] = false
 		
 func updateAnimation():
-	##if isAttacking: return
+	if isAttacking: return
 	
 	if velocity.length() == 0:
 		animations["parameters/conditions/isIdle"] = true
@@ -47,18 +46,12 @@ func updateAnimation():
 	else:
 		animations["parameters/conditions/isIdle"] = false
 		animations["parameters/conditions/isMoving"] = true
-		var direction = 0
-		match [velocity.x, velocity.y]:
-			[ var x, var _y] when x < 0:
-				direction = 1
-			[ var x, var _y] when x > 0:
-				direction = 2
-			[ var _x, var y] when y < 0:
-				direction = 3
-			_:
-				direction = 0
-		animations.set("parameters/direction/current_state", direction)
-		animations.set("parameters/lastDirection/current_state", direction)
+		
+		var direction = velocity.normalized()
+		
+		animations["parameters/Idle/blend_position"] = direction
+		animations["parameters/Move/blend_position"] = direction
+		animations["parameters/Attack/blend_position"] = direction
 
 func handleCollision():
 	for i in get_slide_collision_count():

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -492,7 +492,7 @@ advance_condition = &"isMoving"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_7uv3b"]
 advance_mode = 2
-advance_condition = &"isSwinging"
+advance_condition = &"isAttacking"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_26nfc"]
 switch_mode = 2
@@ -501,7 +501,7 @@ advance_condition = &"isIdle"
 
 [sub_resource type="AnimationNodeStateMachineTransition" id="AnimationNodeStateMachineTransition_0orgj"]
 advance_mode = 2
-advance_condition = &"isSwinging"
+advance_condition = &"isAttacking"
 
 [sub_resource type="AnimationNodeStateMachine" id="AnimationNodeStateMachine_j87il"]
 states/Attack/node = SubResource("AnimationNodeBlendSpace2D_rby2h")
@@ -553,9 +553,9 @@ process_thread_messages = 0
 reset_on_save = false
 tree_root = SubResource("AnimationNodeStateMachine_j87il")
 anim_player = NodePath("../AnimationPlayer")
+parameters/conditions/isAttacking = false
 parameters/conditions/isIdle = false
 parameters/conditions/isMoving = false
-parameters/conditions/isSwinging = false
 parameters/Attack/blend_position = Vector2(0, 0)
 parameters/Idle/blend_position = Vector2(0.00270033, 0.00440526)
 parameters/Move/blend_position = Vector2(0, 0)


### PR DESCRIPTION
### Issue

Works On {#9}

### Notes

- Added AnimationStateMachineTree to player scene
  - Tree is equip with states corresponding to actions: Move, Idle, and Attack
- Replaced prior AnimationPlayer code with AnimationTree for future easier and more readable code

### Testing

Animations seem to be consistent with main's post AnimationTree changes
![godot windows opt tools 64_5Imqy5izti](https://github.com/KawaProductions/BoyoRPG/assets/47233439/832cd259-3cfa-4dda-9cf3-cfb1bee8b08f)
